### PR TITLE
Fix sf namespace bug

### DIFF
--- a/R/read_sf.R
+++ b/R/read_sf.R
@@ -154,7 +154,7 @@ read_sf <- function(geog,
     # Read in shapefile
     suppressWarnings({
       for(i in 1:length(url)){
-        if (exists("sf") != TRUE){
+        if (rlang::env_has(nms = "sf") != TRUE){
           try(
             sf <- st_read(url[i], quiet = TRUE) %>%
               select(-tidyselect::any_of(c("objectd"))),
@@ -162,7 +162,7 @@ read_sf <- function(geog,
           )
         }
       }
-      if (exists("sf") != TRUE){
+      if (rlang::env_has(nms = "sf") != TRUE){
         stop("The shapefile you have requested doesn't seem to exist, sorry!")
       }
     })

--- a/tests/testthat/test-read_sf.R
+++ b/tests/testthat/test-read_sf.R
@@ -81,3 +81,11 @@ test_that("NUTS3", {
   expect_lt(sf::st_bbox(x)$ymax, 60.9)
   expect_lt(sf::st_bbox(x)$xmax, 1.8)
 })
+
+test_that("Namespace clashes resolve", {
+
+sf <- read_sf(geog = "NAT", year = 2021)
+sf2 <- read_sf(geog = "GOR", year = 2021)
+expect_false(identical(sf, sf2))
+
+})


### PR DESCRIPTION
If the user makes an object called `sf`, the function reloads the saved object and not the new shape file. `exists` checks everywhere whereas `rlang::env_has` checks only in the function namespace.

The unit test might be overkill but it illustrates the bug.